### PR TITLE
Add model visualization utility

### DIFF
--- a/pytorch_grad_cam/__init__.py
+++ b/pytorch_grad_cam/__init__.py
@@ -22,3 +22,4 @@ import pytorch_grad_cam.utils.model_targets
 import pytorch_grad_cam.utils.reshape_transforms
 import pytorch_grad_cam.metrics.cam_mult_image
 import pytorch_grad_cam.metrics.road
+from pytorch_grad_cam.model_visualizer import ModelVisualizer

--- a/pytorch_grad_cam/model_visualizer.py
+++ b/pytorch_grad_cam/model_visualizer.py
@@ -1,0 +1,63 @@
+import matplotlib.pyplot as plt
+import numpy as np
+import torch
+
+from typing import List, Type, Dict, Union
+
+from .base_cam import BaseCAM
+
+
+class ModelVisualizer:
+    """Compute and visualize layer importances using CAMs."""
+
+    def __init__(
+        self,
+        model: torch.nn.Module,
+        cam_methods: Union[Type[BaseCAM], List[Type[BaseCAM]]],
+        reshape_transform=None,
+    ) -> None:
+        if not isinstance(cam_methods, list):
+            cam_methods = [cam_methods]
+        self.cam_methods = cam_methods
+        self.model = model.eval()
+        self.reshape_transform = reshape_transform
+        self.device = next(self.model.parameters()).device
+        self.conv_layers = [
+            (name, module)
+            for name, module in self.model.named_modules()
+            if isinstance(module, torch.nn.Conv2d)
+        ]
+
+    def _compute_cam(
+        self, cam_cls: Type[BaseCAM], layer: torch.nn.Module, input_tensor, targets
+    ) -> np.ndarray:
+        with cam_cls(self.model, [layer], reshape_transform=self.reshape_transform) as cam:
+            return cam(input_tensor=input_tensor, targets=targets)
+
+    def compute_importances(
+        self, input_tensor: torch.Tensor, targets=None
+    ) -> Dict[str, np.ndarray]:
+        input_tensor = input_tensor.to(self.device)
+        importances: Dict[str, np.ndarray] = {}
+        for name, layer in self.conv_layers:
+            cams = [
+                self._compute_cam(cam_cls, layer, input_tensor, targets)
+                for cam_cls in self.cam_methods
+            ]
+            cam_avg = np.mean(np.stack(cams, axis=0), axis=0)
+            importances[name] = cam_avg
+        return importances
+
+    def visualize(self, input_tensor: torch.Tensor, targets=None, cmap: str = "jet") -> None:
+        importances = self.compute_importances(input_tensor, targets)
+        num_layers = len(importances)
+        fig, axes = plt.subplots(1, num_layers, figsize=(4 * num_layers, 4))
+        if num_layers == 1:
+            axes = [axes]
+        for ax, (name, cam) in zip(axes, importances.items()):
+            ax.imshow(cam[0], cmap=cmap)
+            ax.set_title(name)
+            ax.axis("off")
+        plt.tight_layout()
+        plt.show()
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ tqdm
 opencv-python
 matplotlib
 scikit-learn
+seaborn

--- a/tutorials/model_visualizer_demo.py
+++ b/tutorials/model_visualizer_demo.py
@@ -1,0 +1,19 @@
+import cv2
+import numpy as np
+import torch
+from torchvision import models
+
+from pytorch_grad_cam import GradCAM, ScoreCAM
+from pytorch_grad_cam.model_visualizer import ModelVisualizer
+from pytorch_grad_cam.utils.image import preprocess_image
+
+
+if __name__ == "__main__":
+    model = models.resnet18(pretrained=True)
+    visualizer = ModelVisualizer(model, [GradCAM, ScoreCAM])
+
+    img = cv2.imread("examples/both.png")
+    img = np.float32(img) / 255
+    input_tensor = preprocess_image(img)
+
+    visualizer.visualize(input_tensor)


### PR DESCRIPTION
## Summary
- add ModelVisualizer class for computing CAMs across conv layers
- export ModelVisualizer from package
- demonstrate usage in tutorials/model_visualizer_demo.py
- require seaborn for visualizations

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torchvision')*