### PR TITLE
Add 1D convolution support

### DIFF
--- a/pytorch_grad_cam/ablation_cam.py
+++ b/pytorch_grad_cam/ablation_cam.py
@@ -99,7 +99,8 @@ class AblationCAM(BaseCAM):
             for batch_index, (target, tensor) in enumerate(
                     zip(targets, input_tensor)):
                 new_scores = []
-                batch_tensor = tensor.repeat(self.batch_size, 1, 1, 1)
+                repeat_dims = [self.batch_size, 1] + [1] * (tensor.dim() - 2)
+                batch_tensor = tensor.repeat(*repeat_dims)
 
                 # Check which channels should be ablated. Normally this will be all channels,
                 # But we can also try to speed this up by using a low

--- a/pytorch_grad_cam/ablation_layer.py
+++ b/pytorch_grad_cam/ablation_layer.py
@@ -64,8 +64,9 @@ class AblationLayer(torch.nn.Module):
         """ This creates the next batch of activations from the layer.
             Just take corresponding batch member from activations, and repeat it num_channels_to_ablate times.
         """
-        self.activations = activations[input_batch_index, :, :, :].clone(
-        ).unsqueeze(0).repeat(num_channels_to_ablate, 1, 1, 1)
+        selected = activations[input_batch_index].clone().unsqueeze(0)
+        repeat_params = [num_channels_to_ablate, 1] + [1] * (selected.dim() - 2)
+        self.activations = selected.repeat(*repeat_params)
 
     def __call__(self, x):
         output = self.activations

--- a/pytorch_grad_cam/base_cam.py
+++ b/pytorch_grad_cam/base_cam.py
@@ -75,14 +75,18 @@ class BaseCAM:
         weights = self.get_cam_weights(input_tensor, target_layer, targets, activations, grads)
         if isinstance(activations, torch.Tensor):
             activations = activations.cpu().detach().numpy()
+        # 1D conv
+        if len(activations.shape) == 3:
+            weighted_activations = weights[:, :, None] * activations
         # 2D conv
-        if len(activations.shape) == 4:
+        elif len(activations.shape) == 4:
             weighted_activations = weights[:, :, None, None] * activations
         # 3D conv
         elif len(activations.shape) == 5:
             weighted_activations = weights[:, :, None, None, None] * activations
         else:
-            raise ValueError(f"Invalid activation shape. Get {len(activations.shape)}.")
+            raise ValueError(
+                f"Invalid activation shape. Get {len(activations.shape)}.")
 
         if eigen_smooth:
             cam = get_2d_projection(weighted_activations)
@@ -129,15 +133,23 @@ class BaseCAM:
         cam_per_layer = self.compute_cam_per_layer(input_tensor, targets, eigen_smooth)
         return self.aggregate_multi_layers(cam_per_layer)
 
-    def get_target_width_height(self, input_tensor: torch.Tensor) -> Tuple[int, int]:
-        if len(input_tensor.shape) == 4:
+    def get_target_width_height(self, input_tensor: torch.Tensor) -> Tuple[int, ...]:
+        if len(input_tensor.shape) == 3:
+            length = input_tensor.size(-1)
+            return (length,)
+        elif len(input_tensor.shape) == 4:
             width, height = input_tensor.size(-1), input_tensor.size(-2)
             return width, height
         elif len(input_tensor.shape) == 5:
-            depth, width, height = input_tensor.size(-1), input_tensor.size(-2), input_tensor.size(-3)
+            depth, width, height = (
+                input_tensor.size(-1),
+                input_tensor.size(-2),
+                input_tensor.size(-3),
+            )
             return depth, width, height
         else:
-            raise ValueError("Invalid input_tensor shape. Only 2D or 3D images are supported.")
+            raise ValueError(
+                "Invalid input_tensor shape. Only 1D, 2D or 3D images are supported.")
 
     def compute_cam_per_layer(
         self, input_tensor: torch.Tensor, targets: List[torch.nn.Module], eigen_smooth: bool

--- a/pytorch_grad_cam/fullgrad_cam.py
+++ b/pytorch_grad_cam/fullgrad_cam.py
@@ -16,8 +16,13 @@ class FullGrad(BaseCAM):
                 "Warning: target_layers is ignored in FullGrad. All bias layers will be used instead")
 
         def layer_with_2D_bias(layer):
-            bias_target_layers = [torch.nn.Conv2d, torch.nn.BatchNorm2d]
-            if type(layer) in bias_target_layers and layer.bias is not None:
+            bias_target_layers = [
+                torch.nn.Conv1d,
+                torch.nn.Conv2d,
+                torch.nn.BatchNorm1d,
+                torch.nn.BatchNorm2d,
+            ]
+            if type(layer) in bias_target_layers and getattr(layer, "bias", None) is not None:
                 return True
             return False
         target_layers = find_layer_predicate_recursive(
@@ -63,7 +68,7 @@ class FullGrad(BaseCAM):
         # Loop over the saliency image from every layer
         assert(len(self.bias_data) == len(grads_list))
         for bias, grads in zip(self.bias_data, grads_list):
-            bias = bias[None, :, None, None]
+            bias = bias.reshape([1, -1] + [1] * (grads.ndim - 2))
             # In the paper they take the absolute value,
             # but possibily taking only the positive gradients will work
             # better.
@@ -76,8 +81,13 @@ class FullGrad(BaseCAM):
         if eigen_smooth:
             # Resize to a smaller image, since this method typically has a very large number of channels,
             # and then consumes a lot of memory
+            if isinstance(target_size, (tuple, list)) and len(target_size) > 1:
+                small_size = (target_size[0] // 8, target_size[1] // 8)
+            else:
+                size = target_size[0] if isinstance(target_size, (tuple, list)) else target_size
+                small_size = size // 8
             cam_per_target_layer = scale_accross_batch_and_channels(
-                cam_per_target_layer, (target_size[0] // 8, target_size[1] // 8))
+                cam_per_target_layer, small_size)
             cam_per_target_layer = get_2d_projection(cam_per_target_layer)
             cam_per_target_layer = cam_per_target_layer[:, None, :, :]
             cam_per_target_layer = scale_accross_batch_and_channels(

--- a/pytorch_grad_cam/grad_cam.py
+++ b/pytorch_grad_cam/grad_cam.py
@@ -19,14 +19,16 @@ class GradCAM(BaseCAM):
                         target_category,
                         activations,
                         grads):
-        # 2D image
-        if len(grads.shape) == 4:
+        if len(grads.shape) == 3:
+            return np.mean(grads, axis=(2,))
+
+        elif len(grads.shape) == 4:
             return np.mean(grads, axis=(2, 3))
-        
-        # 3D image
+
         elif len(grads.shape) == 5:
             return np.mean(grads, axis=(2, 3, 4))
-        
+
         else:
-            raise ValueError("Invalid grads shape." 
-                             "Shape of grads should be 4 (2D image) or 5 (3D image).")
+            raise ValueError(
+                "Invalid grads shape."
+                "Shape of grads should be 3 (1D), 4 (2D) or 5 (3D) images.")

--- a/pytorch_grad_cam/grad_cam_plusplus.py
+++ b/pytorch_grad_cam/grad_cam_plusplus.py
@@ -19,14 +19,27 @@ class GradCAMPlusPlus(BaseCAM):
         grads_power_2 = grads**2
         grads_power_3 = grads_power_2 * grads
         # Equation 19 in https://arxiv.org/abs/1710.11063
-        sum_activations = np.sum(activations, axis=(2, 3))
+        if len(activations.shape) == 3:
+            axes = (2,)
+        elif len(activations.shape) == 4:
+            axes = (2, 3)
+        elif len(activations.shape) == 5:
+            axes = (2, 3, 4)
+        else:
+            raise ValueError(
+                "Invalid activations shape."
+                "Shape should be 3 (1D), 4 (2D) or 5 (3D).")
+
+        sum_activations = np.sum(activations, axis=axes)
         eps = 0.000001
-        aij = grads_power_2 / (2 * grads_power_2 +
-                               sum_activations[:, :, None, None] * grads_power_3 + eps)
+        aij = grads_power_2 / (
+            2 * grads_power_2 +
+            sum_activations[(...,) + (None,) * (grads.ndim - 2)] * grads_power_3 +
+            eps
+        )
         # Now bring back the ReLU from eq.7 in the paper,
         # And zero out aijs where the activations are 0
         aij = np.where(grads != 0, aij, 0)
-
         weights = np.maximum(grads, 0) * aij
-        weights = np.sum(weights, axis=(2, 3))
+        weights = np.sum(weights, axis=axes)
         return weights

--- a/pytorch_grad_cam/score_cam.py
+++ b/pytorch_grad_cam/score_cam.py
@@ -21,23 +21,27 @@ class ScoreCAM(BaseCAM):
                         activations,
                         grads):
         with torch.no_grad():
-            upsample = torch.nn.UpsamplingBilinear2d(
-                size=input_tensor.shape[-2:])
-            activation_tensor = torch.from_numpy(activations)
-            activation_tensor = activation_tensor.to(self.device)
-
-            upsampled = upsample(activation_tensor)
-
-            maxs = upsampled.view(upsampled.size(0),
-                                  upsampled.size(1), -1).max(dim=-1)[0]
-            mins = upsampled.view(upsampled.size(0),
-                                  upsampled.size(1), -1).min(dim=-1)[0]
-
-            maxs, mins = maxs[:, :, None, None], mins[:, :, None, None]
-            upsampled = (upsampled - mins) / (maxs - mins + 1e-8)
-
-            input_tensors = input_tensor[:, None,
-                                         :, :] * upsampled[:, :, None, :, :]
+            activation_tensor = torch.from_numpy(activations).to(self.device)
+            if activation_tensor.ndim == 3:
+                upsampled = torch.nn.functional.interpolate(
+                    activation_tensor,
+                    size=input_tensor.shape[-1],
+                    mode="linear",
+                    align_corners=False,
+                )
+                maxs = upsampled.view(upsampled.size(0), upsampled.size(1), -1).max(dim=-1)[0]
+                mins = upsampled.view(upsampled.size(0), upsampled.size(1), -1).min(dim=-1)[0]
+                maxs, mins = maxs[:, :, None], mins[:, :, None]
+                upsampled = (upsampled - mins) / (maxs - mins + 1e-8)
+                input_tensors = input_tensor[:, None, :, :] * upsampled[:, :, None, :]
+            else:
+                upsample = torch.nn.UpsamplingBilinear2d(size=input_tensor.shape[-2:])
+                upsampled = upsample(activation_tensor)
+                maxs = upsampled.view(upsampled.size(0), upsampled.size(1), -1).max(dim=-1)[0]
+                mins = upsampled.view(upsampled.size(0), upsampled.size(1), -1).min(dim=-1)[0]
+                maxs, mins = maxs[:, :, None, None], mins[:, :, None, None]
+                upsampled = (upsampled - mins) / (maxs - mins + 1e-8)
+                input_tensors = input_tensor[:, None, :, :] * upsampled[:, :, None, :, :]
 
             if hasattr(self, "batch_size"):
                 BATCH_SIZE = self.batch_size

--- a/pytorch_grad_cam/shapley_cam.py
+++ b/pytorch_grad_cam/shapley_cam.py
@@ -46,15 +46,17 @@ class ShapleyCAM(BaseCAM):
             activations = self.activations_and_grads.reshape_transform(activations)
             grads = self.activations_and_grads.reshape_transform(grads)
 
-        weight = (grads  - 0.5 * hvp).detach().cpu().numpy()
-        # 2D image
-        if len(activations.shape) == 4:
+        weight = (grads - 0.5 * hvp).detach().cpu().numpy()
+        if len(activations.shape) == 3:
+            weight = np.mean(weight, axis=(2,))
+            return weight
+        elif len(activations.shape) == 4:
             weight = np.mean(weight, axis=(2, 3))
             return weight
-        # 3D image
         elif len(activations.shape) == 5:
             weight = np.mean(weight, axis=(2, 3, 4))
             return weight
         else:
-            raise ValueError("Invalid grads shape."
-                             "Shape of grads should be 4 (2D image) or 5 (3D image).")
+            raise ValueError(
+                "Invalid grads shape."
+                "Shape of grads should be 3 (1D), 4 (2D) or 5 (3D) images.")

--- a/pytorch_grad_cam/utils/image.py
+++ b/pytorch_grad_cam/utils/image.py
@@ -166,10 +166,15 @@ def scale_cam_image(cam, target_size=None):
         img = img / (1e-7 + np.max(img))
         if target_size is not None:
             if len(img.shape) > 2:
-                img = zoom(np.float32(img), [
-                           (t_s / i_s) for i_s, t_s in zip(img.shape, target_size[::-1])])
-            else:
+                img = zoom(
+                    np.float32(img),
+                    [(t_s / i_s) for i_s, t_s in zip(img.shape, target_size[::-1])],
+                )
+            elif len(img.shape) == 2:
                 img = cv2.resize(np.float32(img), target_size)
+            else:
+                size = target_size[0] if isinstance(target_size, (tuple, list)) else target_size
+                img = cv2.resize(np.float32(img)[None, :], (size, 1))[0]
 
         result.append(img)
     result = np.float32(result)
@@ -179,12 +184,11 @@ def scale_cam_image(cam, target_size=None):
 
 def scale_accross_batch_and_channels(tensor, target_size):
     batch_size, channel_size = tensor.shape[:2]
-    reshaped_tensor = tensor.reshape(
-        batch_size * channel_size, *tensor.shape[2:])
+    reshaped_tensor = tensor.reshape(batch_size * channel_size, *tensor.shape[2:])
     result = scale_cam_image(reshaped_tensor, target_size)
-    result = result.reshape(
-        batch_size,
-        channel_size,
-        target_size[1],
-        target_size[0])
+    if isinstance(target_size, (tuple, list)) and len(target_size) > 1:
+        result = result.reshape(batch_size, channel_size, target_size[1], target_size[0])
+    else:
+        size = target_size[0] if isinstance(target_size, (tuple, list)) else target_size
+        result = result.reshape(batch_size, channel_size, size)
     return result

--- a/pytorch_grad_cam/xgrad_cam.py
+++ b/pytorch_grad_cam/xgrad_cam.py
@@ -21,9 +21,20 @@ class XGradCAM(BaseCAM):
                         target_category,
                         activations,
                         grads):
-        sum_activations = np.sum(activations, axis=(2, 3))
+        if len(activations.shape) == 3:
+            axes = (2,)
+        elif len(activations.shape) == 4:
+            axes = (2, 3)
+        elif len(activations.shape) == 5:
+            axes = (2, 3, 4)
+        else:
+            raise ValueError(
+                "Invalid activations shape."
+                "Shape should be 3 (1D), 4 (2D) or 5 (3D).")
+
+        sum_activations = np.sum(activations, axis=axes)
         eps = 1e-7
-        weights = grads * activations / \
-            (sum_activations[:, :, None, None] + eps)
-        weights = weights.sum(axis=(2, 3))
+        weights = grads * activations / (
+            sum_activations[(...,) + (None,) * (grads.ndim - 2)] + eps)
+        weights = weights.sum(axis=axes)
         return weights

--- a/tests/run_1d_tests.py
+++ b/tests/run_1d_tests.py
@@ -1,0 +1,63 @@
+import torch
+import pytest
+
+from pytorch_grad_cam import (
+    GradCAM,
+    ScoreCAM,
+    GradCAMPlusPlus,
+    AblationCAM,
+    XGradCAM,
+    EigenCAM,
+    EigenGradCAM,
+    LayerCAM,
+    FullGrad,
+    KPCA_CAM,
+    ShapleyCAM,
+)
+from pytorch_grad_cam.utils.model_targets import ClassifierOutputTarget
+
+
+class Simple1DCNN(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.conv1 = torch.nn.Conv1d(3, 4, kernel_size=3, padding=1)
+        self.relu1 = torch.nn.ReLU()
+        self.conv2 = torch.nn.Conv1d(4, 8, kernel_size=3, padding=1)
+        self.relu2 = torch.nn.ReLU()
+        self.pool = torch.nn.AdaptiveAvgPool1d(1)
+        self.fc = torch.nn.Linear(8, 2)
+
+    def forward(self, x):
+        x = self.relu1(self.conv1(x))
+        x = self.relu2(self.conv2(x))
+        x = self.pool(x)
+        x = x.view(x.size(0), -1)
+        return self.fc(x)
+
+
+@pytest.mark.parametrize(
+    "cam_method",
+    [
+        ScoreCAM,
+        AblationCAM,
+        GradCAM,
+        GradCAMPlusPlus,
+        XGradCAM,
+        EigenCAM,
+        EigenGradCAM,
+        LayerCAM,
+        FullGrad,
+        KPCA_CAM,
+        ShapleyCAM,
+    ],
+)
+def test_cam_with_conv1d(cam_method):
+    model = Simple1DCNN()
+    target_layers = [model.conv2]
+    cam = cam_method(model=model, target_layers=target_layers)
+    cam.batch_size = 4
+    input_tensor = torch.randn(2, 3, 32)
+    targets = [ClassifierOutputTarget(1) for _ in range(input_tensor.size(0))]
+    grayscale_cam = cam(input_tensor=input_tensor, targets=targets)
+    assert grayscale_cam.shape[0] == input_tensor.shape[0]
+    assert grayscale_cam.shape[1] == input_tensor.shape[2]


### PR DESCRIPTION
## Summary
- extend CAM core utilities for 1D convolution layers
- adapt GradCAM, GradCAM++, XGradCAM, ShapleyCAM and ScoreCAM to accept 1D
- support 1D in Ablation and FullGrad implementations
- update scaling utilities to resize 1D maps
- add tests for using CAMs on 1D Conv networks

## Testing
- `python -m pytest -q` *(fails: ModuleNotFoundError: No module named 'torchvision')*